### PR TITLE
Solve the problem of memory leak

### DIFF
--- a/flow/sliding_window.go
+++ b/flow/sliding_window.go
@@ -119,6 +119,9 @@ func (sw *SlidingWindow) emit() {
 					break
 				}
 			}
+			if slideUpperIndex == 0 {
+				slideUpperIndex = windowUpperIndex - 1
+			}
 			windowSlice := extract(sw.queue.Slice(windowBottomIndex, windowUpperIndex))
 			if windowUpperIndex > 0 {
 				s := sw.queue.Slice(slideUpperIndex+1, windowUpperIndex)


### PR DESCRIPTION
Solve the memory leak problem caused by the equality of sw.size and sw.slide

## Motivation
* Fixes #___
*
## Modifications
* 
## Verify change
* [ ] Make sure the change passes the CI checks.