### PR TITLE
Fix memory leak caused by time.After()

### DIFF
--- a/flow/sliding_window.go
+++ b/flow/sliding_window.go
@@ -108,9 +108,11 @@ func (sw *SlidingWindow) receive() {
 
 // emit is triggered by the sliding interval
 func (sw *SlidingWindow) emit() {
+	ticker := time.NewTicker(sw.slide)
+	defer ticker.Stop()
 	for {
 		select {
-		case <-time.After(sw.slide):
+		case <-ticker.C:
 			sw.Lock()
 			// build a window slice and send it to the out chan
 			var windowBottomIndex int

--- a/flow/throttler.go
+++ b/flow/throttler.go
@@ -64,9 +64,11 @@ func (th *Throttler) quotaHit() bool {
 
 // the scheduled elements counter refresher.
 func (th *Throttler) resetCounterLoop(after time.Duration) {
+	ticker := time.NewTicker(after)
+	defer ticker.Stop()
 	for {
 		select {
-		case <-time.After(after):
+		case <-ticker.C:
 			th.Lock()
 			if th.quotaHit() {
 				th.doNotify()

--- a/flow/tumbling_window.go
+++ b/flow/tumbling_window.go
@@ -76,9 +76,11 @@ func (tw *TumblingWindow) receive() {
 
 // generate and emit a window
 func (tw *TumblingWindow) emit() {
+	ticker := time.NewTicker(tw.size)
+	defer ticker.Stop()
 	for {
 		select {
-		case <-time.After(tw.size):
+		case <-ticker.C:
 			tw.Lock()
 			windowSlice := append(tw.buffer[:0:0], tw.buffer...)
 			tw.buffer = nil


### PR DESCRIPTION
## Motivation
* Fix memory leak casused by time.After()
## Modifications
* Use time.NewTicker() outside the loop
## Verify change
* [ ] Make sure the change passes the CI checks.