### PR TITLE
feat: new flow "batch"

### DIFF
--- a/flow/batch.go
+++ b/flow/batch.go
@@ -1,0 +1,128 @@
+package flow
+
+import (
+	"sync"
+	"time"
+
+	"github.com/reugn/go-streams"
+)
+
+// Batch batches the incoming elements into a slice by size or time.
+// If the batch size is reached or the batch time is elapsed,
+// and the current batch is not empty, it will be emitted.
+// Note: once the batch is emitted, the timer will be reset.
+//
+// in: a(10ms), b(15ms), c(20ms), d(40ms), e(110ms), f(300ms)
+//
+//	-------------- NewBatch(3, 100ms) --------------------
+//
+// out:
+//
+//	[a b c] (max size, timer reset at 20ms)
+//	[d e] (max time, timer reset at 120ms) (between 120ms and 220ms, there is no element, so there is no batch)
+//	[f] (max time, timer reset at 320ms)
+type Batch struct {
+	maxBatchSize int
+	maxWaitTime  time.Duration
+	ticker       *time.Ticker
+	in           chan any
+	out          chan any
+	buffer       []any
+	mu           sync.Mutex
+	done         chan struct{}
+}
+
+// Verify Batch satisfies the Flow interface
+var _ streams.Flow = (*Batch)(nil)
+
+// NewBatch returns a new Batch instance
+//
+// it will batch the incoming elements into a slice
+// whether the batch size is reached or the time is elapsed.
+func NewBatch(maxBatchSize int, maxWaitTime time.Duration) *Batch {
+	if maxBatchSize <= 0 {
+		panic("batch size should greater than 0")
+	}
+
+	bf := &Batch{
+		maxBatchSize: maxBatchSize,
+		maxWaitTime:  maxWaitTime,
+		ticker:       time.NewTicker(maxWaitTime),
+		buffer:       make([]any, 0, maxBatchSize),
+		in:           make(chan any),
+		out:          make(chan any),
+		done:         make(chan struct{}),
+	}
+	go bf.batchBySize()
+	go bf.batchByTime()
+
+	return bf
+}
+
+// Via sends the flow to the next stage via specified flow
+func (bf *Batch) Via(flow streams.Flow) streams.Flow {
+	go bf.transmit(flow)
+
+	return flow
+}
+
+// To sends the flow to the given sink
+func (bf *Batch) To(sink streams.Sink) {
+	bf.transmit(sink)
+}
+
+// Out returns the output channel of the Batch
+func (bf *Batch) Out() <-chan any {
+	return bf.out
+}
+
+// In returns the input channel of the Batch
+func (bf *Batch) In() chan<- any {
+	return bf.in
+}
+
+func (bf *Batch) batchBySize() {
+	for elem := range bf.in {
+		bf.mu.Lock()
+		bf.buffer = append(bf.buffer, elem)
+		bf.mu.Unlock()
+		if len(bf.buffer) >= bf.maxBatchSize {
+			bf.flush()
+		}
+	}
+	close(bf.done)
+	close(bf.out)
+}
+
+func (bf *Batch) batchByTime() {
+	defer bf.ticker.Stop()
+
+	for {
+		select {
+		case <-bf.ticker.C:
+			bf.flush()
+		case <-bf.done:
+			return
+		}
+	}
+}
+
+// flush sends the batched items to the next flow
+func (bf *Batch) flush() {
+	bf.mu.Lock()
+	buffer := bf.buffer
+	bf.buffer = make([]any, 0, bf.maxBatchSize)
+	bf.ticker.Reset(bf.maxWaitTime)
+	bf.mu.Unlock()
+
+	if len(buffer) > 0 {
+		bf.out <- buffer
+	}
+}
+
+func (bf *Batch) transmit(inlet streams.Inlet) {
+	for item := range bf.out {
+		inlet.In() <- item
+	}
+	defer close(inlet.In())
+}

--- a/flow/batch_test.go
+++ b/flow/batch_test.go
@@ -1,0 +1,195 @@
+package flow_test
+
+import (
+	"testing"
+	"time"
+
+	ext "github.com/reugn/go-streams/extension"
+	"github.com/reugn/go-streams/flow"
+)
+
+func TestBatchCase1(t *testing.T) {
+	// only max size is reached
+
+	in := make(chan any)
+	out := make(chan any)
+
+	source := ext.NewChanSource(in)
+	batch := flow.NewBatch(2, time.Millisecond*100)
+
+	inputValues := []string{"a", "b", "c", "d", "e"}
+	go ingestSlice(inputValues, in)
+
+	go closeDeferred(in, time.Millisecond*200)
+
+	go func() {
+		source.
+			Via(batch).
+			To(ext.NewChanSink(out))
+	}()
+
+	gottenValues := make([][]any, 0)
+	for e := range out {
+		gottenValues = append(gottenValues, e.([]any))
+	}
+
+	assertEquals(t, 3, len(gottenValues))
+
+	assertEquals(t, []any{"a", "b"}, gottenValues[0])
+	assertEquals(t, []any{"c", "d"}, gottenValues[1])
+	assertEquals(t, []any{"e"}, gottenValues[2])
+}
+
+func TestBatchCase2(t *testing.T) {
+	// only max time is reached
+
+	in := make(chan any)
+	out := make(chan any)
+
+	source := ext.NewChanSource(in)
+	batch := flow.NewBatch(3, time.Millisecond*10)
+
+	inputValues := []string{"a", "b", "c", "d", "e"}
+	for i, v := range inputValues {
+		go ingestDeferred(v, in, time.Millisecond*time.Duration((i+1)*20))
+	}
+
+	go closeDeferred(in, time.Millisecond*200)
+
+	go func() {
+		source.
+			Via(batch).
+			To(ext.NewChanSink(out))
+	}()
+
+	gottenValues := make([][]any, 0)
+	for e := range out {
+		gottenValues = append(gottenValues, e.([]any))
+	}
+
+	assertEquals(t, 5, len(gottenValues))
+
+	assertEquals(t, []any{"a"}, gottenValues[0])
+	assertEquals(t, []any{"b"}, gottenValues[1])
+	assertEquals(t, []any{"c"}, gottenValues[2])
+	assertEquals(t, []any{"d"}, gottenValues[3])
+	assertEquals(t, []any{"e"}, gottenValues[4])
+}
+
+func TestBatchCase3(t *testing.T) {
+	// both max size and max time are reached.
+	// it's the example in the Batch documentation
+
+	in := make(chan any)
+	out := make(chan any)
+
+	source := ext.NewChanSource(in)
+	batch := flow.NewBatch(3, time.Millisecond*100)
+
+	go ingestDeferred("a", in, time.Millisecond*10)
+	go ingestDeferred("b", in, time.Millisecond*15)
+	go ingestDeferred("c", in, time.Millisecond*20)
+	// batch1: [a b c] (max size)
+
+	// ticker reset at time 20ms
+
+	go ingestDeferred("d", in, time.Millisecond*40)
+	go ingestDeferred("e", in, time.Millisecond*110)
+
+	// batch2: [d e] (max time)
+
+	// ticker reached timeout at 120ms and reset at 120ms
+
+	// between 120ms and 220ms, there is no element, so there is no batch
+
+	go ingestDeferred("f", in, time.Millisecond*300)
+
+	// batch3: [f] (max time)
+
+	go closeDeferred(in, time.Millisecond*330)
+
+	go func() {
+		source.
+			Via(batch).
+			To(ext.NewChanSink(out))
+	}()
+
+	gottenValues := make([][]any, 0)
+	for e := range out {
+		gottenValues = append(gottenValues, e.([]any))
+	}
+
+	assertEquals(t, 3, len(gottenValues))
+
+	assertEquals(t, []any{"a", "b", "c"}, gottenValues[0])
+	assertEquals(t, []any{"d", "e"}, gottenValues[1])
+	assertEquals(t, []any{"f"}, gottenValues[2])
+}
+
+func TestBatchCase4(t *testing.T) {
+	// both max size and max time are reached and more complex
+
+	in := make(chan any)
+	out := make(chan any)
+
+	source := ext.NewChanSource(in)
+	batch := flow.NewBatch(3, time.Millisecond*100)
+
+	go ingestSlice([]string{"a", "b"}, in)
+	go ingestDeferred("c", in, time.Millisecond*50)
+
+	// batch1: [a b c] (max size)
+
+	// ticker reset at time 50ms
+
+	go ingestDeferred("d", in, time.Millisecond*60)
+	go ingestDeferred("e", in, time.Millisecond*140)
+
+	// ticker reached timeout at 50+100=150ms and reset at 150ms
+	// so batch2: [d e]
+
+	go ingestDeferred("f", in, time.Millisecond*160)
+	go ingestDeferred("g", in, time.Millisecond*175)
+	go ingestDeferred("h", in, time.Millisecond*180)
+
+	// ticker reset at 180ms because of the max size reached
+	// so batch3: [f g h]
+
+	go ingestDeferred("i", in, time.Millisecond*185)
+
+	// ticker reset at 279ms because of the max size reached
+	// so batch4: [i j]
+
+	go ingestDeferred("j", in, time.Millisecond*279)
+
+	// ticker reached timeout at 279+100=379ms and reset at 379ms
+	// and this batch is empty, so it will be skipped
+
+	go ingestDeferred("k", in, time.Millisecond*400)
+	go ingestDeferred("l", in, time.Millisecond*420)
+
+	// ticker reached timeout at 379+100=479ms and reset at 479ms
+	// so batch5: [k l]
+
+	go closeDeferred(in, time.Millisecond*500)
+
+	go func() {
+		source.
+			Via(batch).
+			To(ext.NewChanSink(out))
+	}()
+
+	gottenValues := make([][]any, 0)
+	for e := range out {
+		gottenValues = append(gottenValues, e.([]any))
+	}
+
+	assertEquals(t, 5, len(gottenValues))
+
+	assertEquals(t, []any{"a", "b", "c"}, gottenValues[0])
+	assertEquals(t, []any{"d", "e"}, gottenValues[1])
+	assertEquals(t, []any{"f", "g", "h"}, gottenValues[2])
+	assertEquals(t, []any{"i", "j"}, gottenValues[3])
+	assertEquals(t, []any{"k", "l"}, gottenValues[4])
+
+}


### PR DESCRIPTION
## Motivation

* Implements #48

I really like this library! It has successfully decoupled my business and stream processing logic!

But I have a requirement that I can't seem to satisfy with the original library: if elements reach a certain number, or reach a certain time, they are packed into a slice and packaged and sent to the next flow.

## Modifications

```go
// Batch batches the incoming elements into a slice by size or time.
// If the batch size is reached or the batch time is elapsed,
// and the current batch is not empty, it will be emitted.
// Note: once the batch is emitted, the timer will be reset.
//
// in: a(10ms), b(15ms), c(20ms), d(40ms), e(110ms), f(300ms)
//
//	-------------- NewBatch(3, 100ms) --------------------
//
// out:
//
//	[a b c] (max size, timer reset at 20ms)
//	[d e] (max time, timer reset at 120ms) (between 120ms and 220ms, there is no element, so there is no batch)
//	[f] (max time, timer reset at 320ms)
```

## Verify change
* [x] Make sure the change passes the CI checks.
* [x] Unit Tests

![image](https://user-images.githubusercontent.com/36830265/222313735-bb629b88-23e2-4224-9965-760cf81fd2e4.png)

## Anything else

1. Thank you for reviewing!

2. I'm not sure about variable naming (flow names, parameter names, etc.), so if you have a better suggestion, be sure to talk to me!

3. Maybe we can split this Flow into two separate flows?

One is packed only according to the batch size (there may be problems with no new elements for a long time, which keeps the next batch from being sent, and the last batch not reaching the expected value after the previous one ends); the other one is consistent with the current flow, but the name can be changed, like BatchBySizeAndTime ?

But the two flows are not as concise as one flow, do you have any ideas?
