### PR TITLE
feat: add buffer flow (#48)

### DIFF
--- a/flow/buffer.go
+++ b/flow/buffer.go
@@ -1,0 +1,105 @@
+package flow
+
+import (
+	"sync"
+	"time"
+
+	"github.com/reugn/go-streams"
+)
+
+// NewBuffer create a new Buffer instance
+// timeout is a given time interval for a timer that used to control the emits frequency
+// size is the maximum number of data in the buffer slice each time
+// after each send, the timer is reset
+func NewBuffer[T any](timeout time.Duration, size, parallelism uint) *Buffer[T] {
+	batch := &Buffer[T]{
+		timeout:     timeout,
+		size:        size,
+		in:          make(chan interface{}),
+		out:         make(chan interface{}),
+		parallelism: parallelism,
+	}
+	go batch.doStream()
+	return batch
+}
+
+// Buffer emits buffers of items it collects from the source
+// either from a given count or at a given time interval.
+type Buffer[T any] struct {
+	timeout     time.Duration
+	size        uint
+	in          chan interface{}
+	out         chan interface{}
+	parallelism uint
+}
+
+// Via streams data through the given flow
+func (m *Buffer[T]) Via(flow streams.Flow) streams.Flow {
+	go m.transmit(flow)
+	return flow
+}
+
+// To streams data to the given sink
+func (m *Buffer[T]) To(sink streams.Sink) {
+	m.transmit(sink)
+}
+
+// Out returns an output channel for sending data
+func (m *Buffer[T]) Out() <-chan interface{} {
+	return m.out
+}
+
+// In returns an input channel for receiving data
+func (m *Buffer[T]) In() chan<- interface{} {
+	return m.in
+}
+
+func (m *Buffer[T]) transmit(inlet streams.Inlet) {
+	for elem := range m.Out() {
+		inlet.In() <- elem
+	}
+	close(inlet.In())
+}
+
+func (m *Buffer[T]) doStream() {
+	wg := new(sync.WaitGroup)
+	tick := time.NewTicker(m.timeout)
+	defer tick.Stop()
+
+	for i := 0; i < int(m.parallelism); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			batches := make([]T, 0, m.size)
+			defer func() {
+				if len(batches) > 0 {
+					m.out <- batches
+				}
+			}()
+
+			for {
+				select {
+				case v, ok := <-m.in:
+					if ok {
+						batches = append(batches, v.(T))
+						if len(batches) >= int(m.size) {
+							m.out <- batches
+							tick.Reset(m.timeout)
+							batches = make([]T, 0, m.size)
+						}
+					} else {
+						return
+					}
+				case <-tick.C:
+					if len(batches) > 0 {
+						m.out <- batches
+						batches = make([]T, 0, m.size)
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(m.out)
+}

--- a/flow/buffer_test.go
+++ b/flow/buffer_test.go
@@ -1,0 +1,56 @@
+package flow_test
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/reugn/go-streams/extension"
+	"github.com/reugn/go-streams/flow"
+)
+
+// TestNewBuffer ...
+func TestNewBuffer(t *testing.T) {
+	randTime := 1 + rand.Intn(15)
+	ch := make(chan any)
+	go func() {
+		for i := 0; i < 100; i++ {
+			time.Sleep(time.Millisecond * time.Duration(randTime))
+			ch <- i
+		}
+		close(ch)
+	}()
+	source := extension.NewChanSource(ch)
+
+	result := sync.Map{}
+	pTime := time.Now()
+
+	// m collects grouped results after calling `NewBuffer`
+	m := flow.NewMap(func(i []int) interface{} {
+		if len(i) > 6 {
+			t.Fatalf("%v overflow the size", len(i))
+		}
+		fmt.Printf("buffer data array:%v, time consuming:%v\n", i, time.Since(pTime))
+		pTime = time.Now()
+		for _, v := range i {
+			_, ok := result.Load(v)
+			if ok {
+				t.Fatalf("found duplicate data:%v", v)
+			}
+			result.Store(v, "")
+		}
+		return i
+	}, 1)
+
+	source.Via(flow.NewBuffer[int](time.Millisecond*100, 6, 4)).Via(m).To(extension.NewIgnoreSink())
+
+	// All data coming from the source will go through `m`
+	for i := 0; i < 100; i++ {
+		_, ok := result.Load(i)
+		if !ok {
+			t.Fatalf("cannot find %v", i)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation
* Implements #48 
## Modifications
```
// Batch batches the incoming elements into a slice by size or time.
// If the batch size is reached or the batch time is elapsed,
// and the current batch is not empty, it will be emitted.
// Note: once the batch is emitted, the timer will be reset.
//
// in: a(10ms), b(15ms), c(20ms), d(40ms), e(110ms), f(300ms)
//
//	-------------- NewBatch(3, 100ms) --------------------
//
// out:
//
//	[a b c] (max size, timer reset at 20ms)
//	[d e] (max time, timer reset at 120ms) (between 120ms and 220ms, there is no element, so there is no batch)
//	[f] (max time, timer reset at 320ms)
```
## Verify change
* [X] Make sure the change passes the CI checks.