### PR TITLE
Fix memory issue in PriorityQueue Slice method

### DIFF
--- a/flow/queue.go
+++ b/flow/queue.go
@@ -65,5 +65,11 @@ func (pq *PriorityQueue) Update(item *Item, newEpoch int64) {
 
 // Slice returns a sliced PriorityQueue using the given bounds.
 func (pq PriorityQueue) Slice(start, end int) PriorityQueue {
-	return pq[start:end]
+	// Create a new slice with the desired length
+	subQueue := make(PriorityQueue, end-start)
+
+	// Copy the elements from the original slice to the new slice
+	copy(subQueue, pq[start:end])
+
+	return subQueue
 }


### PR DESCRIPTION
## Motivation
* Fixes potential memory retention issue in PriorityQueue Slice method.
* In Go, slices share the same underlying memory block. This means that even if we are only interested in a small subset of the data, the entire array is kept in memory. In scenarios with unbounded streams, this could result in significant memory not being reclaimed.
## Modifications
* Updated the Slice method to create a new slice and copy the relevant elements.
* This change ensures better memory management without altering the method’s functionality.
## Verify change
* [x] Make sure the change passes the CI checks.